### PR TITLE
Add Lecture and Schedule classes to domain entities

### DIFF
--- a/src/UniversitySystem.Domain/Entities/Lecture.cs
+++ b/src/UniversitySystem.Domain/Entities/Lecture.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Copyright (c) 2025 AOLabs
+ * This file is part of the AOLabs University System project.
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at:
+ * https://opensource.org/licenses/MIT
+ *
+ * You are free to use, modify, and distribute this file
+ * under the terms of the license.
+ */
+
+using UniversitySystem.Domain.Common;
+
+namespace UniversitySystem.Domain.Entities;
+
+public class Lecture : BaseEntity
+{
+    private string _topic = string.Empty;
+
+    public DateOnly Date { get; set; }
+
+    public string Topic
+    {
+        get => _topic;
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("Lecture topic is required", nameof(value));
+
+            _topic = value;
+        }
+    }
+
+    public Guid CourseId { get; set; }
+
+    public Guid InstructorId { get; set; }
+
+    public Guid ScheduleId { get; set; }
+
+    public Course Course { get; set; } = default!;
+
+    public Instructor Instructor { get; set; } = default!;
+
+    public Schedule Schedule { get; set; } = default!;
+
+    public ICollection<Attendance> Attendances { get; set; } = new List<Attendance>();
+
+    public Lecture(string topic)
+    {
+        Topic = topic;
+    }
+
+    // Parameterless constructor for EF Core
+    private Lecture() { }
+}

--- a/src/UniversitySystem.Domain/Entities/Schedule.cs
+++ b/src/UniversitySystem.Domain/Entities/Schedule.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright (c) 2025 AOLabs
+ * This file is part of the AOLabs University System project.
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at:
+ * https://opensource.org/licenses/MIT
+ *
+ * You are free to use, modify, and distribute this file
+ * under the terms of the license.
+ */
+
+using UniversitySystem.Domain.Common;
+
+namespace UniversitySystem.Domain.Entities;
+
+public class Schedule : BaseEntity
+{
+    private string _roomNumber = string.Empty;
+
+    public DayOfWeek DayOfWeek { get; set; }
+
+    public TimeOnly StartTime { get; set; }
+
+    public TimeOnly EndTime { get; set; }
+
+    public string RoomNumber
+    {
+        get => _roomNumber;
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("Room number is required", nameof(value));
+
+            _roomNumber = value;
+        }
+    }
+
+    public Guid CourseId { get; set; }
+
+    public Guid InstructorId { get; set; }
+
+    public Course Course { get; set; } = default!;
+
+    public Instructor Instructor { get; set; } = default!;
+
+    public ICollection<Lecture> Lectures { get; set; } = new List<Lecture>();
+
+    public Schedule(DayOfWeek dayOfWeek, TimeOnly startTime, TimeOnly endTime, string roomNumber, Guid courseId, Guid instructorId)
+    {
+        DayOfWeek = dayOfWeek;
+        StartTime = startTime;
+        EndTime = endTime;
+        RoomNumber = roomNumber ?? throw new ArgumentNullException(nameof(roomNumber), "Room number is required");
+        CourseId = courseId;
+        InstructorId = instructorId;
+    }
+
+    // Parameterless constructor for EF Core
+    private Schedule() { }
+}


### PR DESCRIPTION
Add Lecture and Schedule classes to domain entities

Introduce `Lecture` and `Schedule` classes with properties for managing lectures and schedules in the University System. Each class includes validation for required fields and constructors for initialization and Entity Framework Core compatibility. Copyright and licensing information added.